### PR TITLE
Fix long not returning html + suggestion windows user

### DIFF
--- a/Apostra (1).ahk
+++ b/Apostra (1).ahk
@@ -363,7 +363,7 @@ IniListRead(path, section, key)
 {	aw := WinExist("A")
 	MyGui := Gui(, "pdl1")
 	Patholoog_tekst := MyGui.AddText("xm section w200", "Patholoog")
-	Patholoog := MyGui.AddDropDownList("ys w500 Choose1", ["AD", "AH", "FC", "DC", "KV", "LF", "JVD", "SV"])
+	Patholoog := MyGui.AddDropDownList("ys w500 Choose1", [A_UserName, "AD", "AH", "FC", "DC", "KV", "LF", "JVD", "SV"])
 	Orgaan_tekst := MyGui.AddText("xm section w200", "Orgaan")
 	Matrix := MyGui.AddDropDownList("ys w500 Choose1", ["Blaas", "Borst", "Cervix", "Hoofd hals", "Long", "Slokdarm-maag Adenocarcinoom", "Slokdarm plaveiselcelcarcinoom"])
 	ScoreText := MyGui.AddText("xm section w200", "Score Type:")
@@ -376,7 +376,7 @@ ScoreTextTPS := MyGui.AddText("xm section w200", "TPS-score:")
 ScoreEditTPS := MyGui.AddEdit("ys w200")
 
 ExternalControlsText := MyGui.AddText("xm section w200", "Externe/interne controles:")
-ExternalControlsCheckbox := MyGui.AddCheckbox("xm section w200", "Controles OK")
+ExternalControlsCheckbox := MyGui.AddCheckbox("xm section w200 Checked", "Controles OK")
 
 MyGui.AddButton("xm w50 h20 default", "OK").OnEvent("click", _PDL1ButtonOK)
 MyGui.Show()
@@ -403,9 +403,10 @@ _PDL1ButtonOK(*)
     CPS_Score := ScoreEditCPS.Text
     TPS_Score := ScoreEditTPS.Text
     externalControlsOK := ExternalControlsCheckbox.Value
+	Patholoogname := Patholoog.text
 
     ; Generate HTML based on the selected organ and scoring method
-    result := SetScoresAndCheckPositivity(selectedOrgan, scoringMethod, CPS_Score, TPS_Score, externalControlsOK, currentDate, Patholoog)
+    result := SetScoresAndCheckPositivity(selectedOrgan, scoringMethod, CPS_Score, TPS_Score, externalControlsOK, currentDate, Patholoogname)
     SendHTML(result, aw)
     MyGui.Destroy()
 }
@@ -487,7 +488,7 @@ if (ScoreEditTPS.Enabled and TPS_Score != "") {
     } else {
         return "Invalid TPS score. Please enter a number."
     }
-}
+	}
         ; Include the external controls status in the HTML
         if (externalControlsOK) {
             externalControlsStatus := "Externe/interne controles zijn conform de vooropgestelde criteria."
@@ -497,7 +498,7 @@ if (ScoreEditTPS.Enabled and TPS_Score != "") {
 
         ; Generate the HTML output 
 		if (organ = "Long") {
-			html := "<b>Immuunhistochemie voor PD-L1 (" FormatTime(,"dd/MM/yyyy") ";" Patholoog.Text ")" "</b><br>"
+			html := "<b>Immuunhistochemie voor PD-L1 (" . FormatTime(,"dd/MM/yyyy") . ";" . Patholoog . ")</b><br>"
 			html .= "<b>Locatie:</b> " organ "<br>"
 			html .= "<b>Techniek:</b> uitgevoerd met 22C3 antilichaam (Agilent) op het Benchmark Ultra toestel (Roche).<br>"
 			html .= "<b>Interpretatie:</b> " explanation "<br>"
@@ -505,18 +506,19 @@ if (ScoreEditTPS.Enabled and TPS_Score != "") {
 			html .= "<b>PD-L1 Score (22C3, Agilent):</b><br>"
 			html .= "- TPS = " . TPS_Score . "%.<br>"
 		} else {
-		html := "<b>Immuunhistochemie voor PD-L1 (" FormatTime(,"dd/MM/yyyy") ";" Patholoog.Text ")" "</b><br>"
-		html .= "<b>Locatie:</b> " organ "<br>"
-		html .= "<b>Techniek:</b> uitgevoerd met 22C3 antilichaam (Agilent) op het Benchmark Ultra toestel (Roche).<br>"
-		html .= "<b>Interpretatie:</b> " explanation "<br>"
-		html .= "<b>Externe/interne controle:</b> " externalControlsStatus "<br>"
-		html .= "<b>PD-L1 Score (22C3, Agilent):</b> <br>" 
-		if ScoreEditCPS.Enabled
-			html .= "- CPS = " CPS_Score ". Dit komt overeen met een " resultaatCPS " resultaat. <br>"
-		if ScoreEditTPS.Enabled
-			html .= "- TPS = " . TPS_Score . "%. Dit komt overeen met een " . resultaatTPS . " resultaat. <br>"
+			html := "<b>Immuunhistochemie voor PD-L1 (" FormatTime(,"dd/MM/yyyy") ";" Patholoog ")" "</b><br>"
+			html .= "<b>Locatie:</b> " organ "<br>"
+			html .= "<b>Techniek:</b> uitgevoerd met 22C3 antilichaam (Agilent) op het Benchmark Ultra toestel (Roche).<br>"
+			html .= "<b>Interpretatie:</b> " explanation "<br>"
+			html .= "<b>Externe/interne controle:</b> " externalControlsStatus "<br>"
+			html .= "<b>PD-L1 Score (22C3, Agilent):</b> <br>" 
+			if ScoreEditCPS.Enabled
+				html .= "- CPS = " CPS_Score ". Dit komt overeen met een " resultaatCPS " resultaat. <br>"
+			if ScoreEditTPS.Enabled
+				html .= "- TPS = " . TPS_Score . "%. Dit komt overeen met een " . resultaatTPS . " resultaat. <br>"
+	}
 		return html
-    }
+    
 }
 }
 }


### PR DESCRIPTION
A_UserName pakt de user die het script gelanceerd heeft. Ismisschien ook een optie om automatisch de juiste patholoog te pakken.Probleem met de optie "Long" was dat de "return html" buiten de haakjes van de "Long" optie stond, en dat hij dus enkel de waarde html returnde als het de andere optie was. Ik heb de "return html" uit de haakjes gehaald.
En er was ook iets mis met die "patholoog" in die custom functie. Enjoy!